### PR TITLE
Fix test DB creation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: "3"
 
 services:
   db:
-    image: mysql:5.7
+    build: mysql/
+    image: mysqlcustom
     volumes:
       - db_data:/var/lib/mysql
     restart: always

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,0 +1,3 @@
+FROM mysql:5.7
+# Add wildcard (%) to end of database name in GRANT statement"
+RUN sed -i 's:\${MYSQL_DATABASE//_/\\\\_}:&%:' /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
In order to run django tests (e.g. `python manage.py test polls`), we
need to be able to create a database called `django_test`, meaning our
MySQL database user needs to be GRANTed those privileges.

This commit does this in the following way:

1.  Find out how the MySQL Docker image creates the database we defined
    in the MYSQL_DATABASE environment variable, and how it GRANTS
    privileges to the user we specified in MYSQL_USER.

    We do this by checking out the `docker-entrypoint.sh` used to create
    the MySQL image:
    https://github.com/docker-library/mysql/blob/master/5.7/docker-entrypoint.sh#L320

    We can see on line 320 that it GRANTs privileges. Now here we can do
    something clever (and perhaps a little nasty).

2.  Modify the script to GRANT access to the other database we need

    If we add a wildcard (represented by '%' in SQL) to the end of the database
    name (which we specified as `django` in the MYSQL_DATABASE environment var),
    the GRANT will not just apply to *that* database, but also to any other
    databases (that do or don't exist) that *start* with the same string.  I.e.
    Because the main datatabase we create is `django`, and the database the test
    suite wants to create is `django_test`, this database can be created using this
    modification.

3.  Modify script into custom MySQL image

    We create a `mysql` directory in the project, with a really simple
    Dockerfile that uses a (rather nasty-looking) `sed` to add the
    wildcard '%' to docker-entrypoont.sh, and then we update the
    docker-compose.yml to use this custom image rather than the default
    MySQL 5.7 image.

Finally, if your database already exists and you want to just make this
permissions modification without blowing everything away, you should be able
to:

    docker-compose exec db mysql -uroot -proot-django mysql --execute "GRANT ALL ON \`django%\`.* to 'django'@'%'; FLUSH PRIVILEGES;"